### PR TITLE
Revert "Bump gvenzl/oracle-free from 23.7 to 23.8 in /oracle"

### DIFF
--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gvenzl/oracle-free:23.8
+FROM ghcr.io/gvenzl/oracle-free:23.7
 
 LABEL org.opencontainers.image.authors="Tailormap/core-developers" \
       org.opencontainers.image.description="An Oracle Free image for the Tailormap stack" \


### PR DESCRIPTION
Reverts Tailormap/tailormap-data#53

because of https://github.com/gvenzl/oci-oracle-free/issues/103