### PR TITLE
HTM-2003: Remove unused GeoServer extension dependencies

### DIFF
--- a/geoserver/maven/pom.xml
+++ b/geoserver/maven/pom.xml
@@ -64,21 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.geoserver.extension</groupId>
-            <artifactId>gs-geopkg-output-wfs</artifactId>
-            <version>${geoserver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geoserver.extension</groupId>
-            <artifactId>gs-excel-wfs</artifactId>
-            <version>${geoserver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geoserver.extension</groupId>
-            <artifactId>gs-dxf-core</artifactId>
-            <version>${geoserver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geoserver.extension</groupId>
             <artifactId>gs-web-resource</artifactId>
             <version>${geoserver.version}</version>
         </dependency>


### PR DESCRIPTION
[![HTM-2003](https://badgen.net/badge/JIRA/HTM-2003/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2003) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Removed several dependencies related to GeoServer extensions, no longer needed because we have the `/extract` endpoint now.

This depends on [HTM-1960: Custom extract functionality for layer attributes](https://github.com/Tailormap/tailormap-api/pull/1672)

- [x] deploy to CD environment

[HTM-2003]: https://b3partners.atlassian.net/browse/HTM-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ